### PR TITLE
Improvements on Filipino translation

### DIFF
--- a/fil.json
+++ b/fil.json
@@ -1,19 +1,19 @@
 {
     "about": {
-        "creatorA": "Ang site na ito ay nilikha at pinapanatili ko, LaShawn Toyoda! Kung nagkakaproblema ka sa paggamit ng site o nahanap ang hindi tama o hindi napapanahong impormasyon, mangyaring makipag-ugnay sa akin sa pamamagitan ng Twitter {0}",
+        "creatorA": "Ang site na ito ay nilikha at pinapanatili ko, si LaShawn Toyoda! Kung nagkakaproblema ka sa paggamit ng site o nakahanap ang hindi tama o hindi napapanahong impormasyon, mangyaring makipag-ugnayan sa akin sa pamamagitan ng Twitter {0}",
         "creatorQ": "Sino ang lumikha ng website na ito?",
-        "supportA": "Ang pinakamahusay na paraan upang makatulong ay sa pamamagitan ng pagsusumite ng anumang mga listahan ng naghihintay na pagkansela na nakatagpo ka sa database. Kung sa tingin mo ay labis na mapagbigay, mangyaring bumili ako ng isang kofi!",
+        "supportA": "Ang pinakamahusay na paraan upang makatulong ay sa pamamagitan ng pagsusumite ng anumang 'cancellation waiting lists' na iyong matatagpuan sa database. Kung sa tingin mo ikaw ay labis na mapagbigay, mangyaring bilihan ako ng isang kofi!",
         "supportQ": "Paano ako makakatulong suportahan ang database?",
-        "trustA": "Ang lahat ng mga link ay humantong sa mga opisyal na mapagkukunan tulad ng klinika at mga website ng gobyerno. Mangyaring basahin ang mga ito nang malalim bago iparehistro ang iyong personal na impormasyon sa kanila.",
+        "trustA": "Ang lahat ng mga links ay humanhantong sa mga opisyal na mapagkukunan tulad ng mga websites ng klinika at gobyerno. Mangyaring basahin ang mga ito bago iparehistro ang iyong personal na impormasyon sa kanila.",
         "trustQ": "Maaari bang pagkatiwalaan ang impormasyong ito?",
-        "welcome": "Maligayang pagdating sa Maghanap ng isang Dok!",
-        "whatIsThisA": "Ito ay isang database na hinimok ng pamayanan upang matulungan ang pagkalat ng impormasyon sa mga klinika na nag-aalok ng mga listahan ng paghihintay para sa pagbabakuna upang hindi sila masayang.",
+        "welcome": "Maligayang pagdating sa Find a Doc!",
+        "whatIsThisA": "Ito ay isang community-driven database upang matulungan ang pagkalat ng impormasyon sa mga klinika na nag-aalok ng mga waiting lists para sa pagbabakuna upang hindi sila masayang.",
         "whatIsThisQ": "Ano ito?"
     },
     "add-clinic": {
         "city": "Lungsod",
         "clinicName": "Pangalan ng klinika",
-        "fillForm": "Punan ang form na ito upang magdagdag ng isang bagong klinika sa database na may listahan ng paghihintay sa pagkansela.",
+        "fillForm": "Punan ang form na ito upang magdagdag ng isang bagong klinika sa database na may cancellation waiting list.",
         "prefecture": "Prefecture",
         "reviewMessage": "Ang klinika na iyong isinumite ay ipapakita matapos itong suriin!",
         "romajiOnly": "Romaji lang",
@@ -38,10 +38,10 @@
         }
     },
     "index": {
-        "title": "Ang Mga Listahan ng Naghihintay sa Pagkansela ng Bakuna sa COVID-19 sa Japan"
+        "title": "COVID-19 Vaccination Cancellation Waiting Lists sa Japan"
     },
     "login": {
-        "clear": "Malinaw",
+        "clear": "Ulitin",
         "email": "Email",
         "login": "Mag log in",
         "password": "Password"


### PR DESCRIPTION
Hi @ourjapanlife!

I've made translation improvements to this PR.

BTW, I'd like to suggest using casual Filipino-English translation instead of formal Filipino. I think that would be more convenient and more natural for Filipino users accessing the website.
If this will be okay, I'll be happy to contribute more.
