### PR TITLE
minor improvements for German

### DIFF
--- a/de.json
+++ b/de.json
@@ -23,12 +23,12 @@
             "cityValidation": "Der Stadtname muss mindestens {0} Zeichen lang sein",
             "clinicRequired": "Klinikname ist erforderlich",
             "clinicValidation": "Der Klinikname muss aus mindestens {0} Zeichen bestehen",
-            "wardRequired": "Ward wird benötigt",
-            "wardValidation": "Der Ward Name muss mindestens {0} Zeichen lang sein",
+            "wardRequired": "Stadtviertel wird benötigt",
+            "wardValidation": "Der Stadtviertel Name muss mindestens {0} Zeichen lang sein",
             "websiteRequired": "Website-URL ist erforderlich",
             "websiteValidation": "Bitte geben Sie eine gültige URL ein"
         },
-        "ward": "Ward",
+        "ward": "Stadtviertel",
         "websiteURL": "Website-URL"
     },
     "admin": {
@@ -41,7 +41,7 @@
         "title": "Wartelisten für die Stornierung von COVID-19-Impfungen in Japan"
     },
     "login": {
-        "clear": "Klar",
+        "clear": "Löschen",
         "email": "Email",
         "login": "Anmeldung",
         "password": "Passwort"


### PR DESCRIPTION
Seems like German was already well translated. Not sure if you want to use the word Ward or its translation= "Stadtviertel", "Stadtteil" or "Statbezirk".
"clear" was translated as the adjective "Klar" but here it means to clear or delete, I thought the more adequate translation is "Löschen"
Good job for all the rest!