### PR TITLE
Improve French translation

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -1,12 +1,12 @@
 {
     "about": {
-        "creatorA": "Ce site a été créé et maintenu par moi, LaShawn Toyoda ! Si vous rencontrez des difficultés pour utiliser le site ou si vous rencontrez des informations incorrectes ou obsolètes, veuillez me contacter via Twitter {0}",
+        "creatorA": "Ce site a été créé et est maintenu par moi, LaShawn Toyoda ! Si vous rencontrez des difficultés pour utiliser le site ou si vous trouvez des informations incorrectes ou obsolètes, merci de me contacter via Twitter {0}",
         "creatorQ": "Qui a créé ce site Web ?",
         "supportA": "La meilleure façon d'aider est de soumettre à la base de données toutes les listes d'attente d'annulation que vous rencontrez. Si vous vous sentez très généreux, achetez-moi un kofi !",
-        "supportQ": "Comment puis-je aider à soutenir la base de données ?",
-        "trustA": "Tous les liens mènent à des ressources officielles telles que les sites Web des cliniques et du gouvernement. Veuillez les lire attentivement avant d'enregistrer vos informations personnelles avec eux.",
+        "supportQ": "Comment puis-je aider à soutenir la base de données ?",
+        "trustA": "Tous les liens mènent à des ressources officielles telles que les sites web de cliniques et du gouvernement. Veuillez les lire attentivement avant d'y enregistrer vos informations personnelles.",
         "trustQ": "Ces informations sont-elles fiables ?",
-        "welcome": "Bienvenue à Find a Doc !",
+        "welcome": "Bienvenue sur Find a Doc !",
         "whatIsThisA": "Il s'agit d'une base de données communautaire pour aider à diffuser des informations sur les cliniques qui proposent des listes d'attente pour les vaccinations afin que les doses de vaccin ne soient pas gaspillées.",
         "whatIsThisQ": "Qu'est-ce que c'est ?"
     },
@@ -17,18 +17,18 @@
         "prefecture": "Préfecture",
         "reviewMessage": "La clinique que vous avez soumise sera affichée après avoir été examinée !",
         "romajiOnly": "Romaji seulement",
-        "submitClinic": "Soumettre Clinique",
+        "submitClinic": "Soumettre la clinique",
         "validations": {
             "cityRequired": "La ville est requise",
             "cityValidation": "Le nom de la ville doit comporter au moins {0} caractères",
             "clinicRequired": "Le nom de la clinique est requis",
             "clinicValidation": "Le nom de la clinique doit comporter au moins {0} caractères",
-            "wardRequired": "Le nom du quartier est requis",
-            "wardValidation": "Le nom du quartier doit comporter au moins {0} caractères",
-            "websiteRequired": "L'URL du site Web est requise",
+            "wardRequired": "Le nom de l'arrondissement (区) est requis",
+            "wardValidation": "Le nom de l'arrondissement (区) doit comporter au moins {0} caractères",
+            "websiteRequired": "L'URL du site web est requise",
             "websiteValidation": "Veuillez saisir une URL valide"
         },
-        "ward": "Quartier",
+        "ward": "Arrondissement (区)",
         "websiteURL": "URL de site web"
     },
     "admin": {
@@ -38,12 +38,12 @@
         }
     },
     "index": {
-        "title": "Listes d'attente d'annulation pour la vaccination COVID-19 au Japon"
+        "title": "Listes d'attente d'annulation pour la vaccination contre la COVID-19 au Japon"
     },
     "login": {
         "clear": "Effacer",
         "email": "E-mail",
-        "login": "Connexion",
+        "login": "Login",
         "password": "Mot de passe"
     }
 }


### PR DESCRIPTION
- Slight modifications improving the French text.
- Specifying 'arrondissements (区)' to translate 'wards', since arrondissement can be ambiguous despite being the official translation of 区.