### PR TITLE
DE: Redo overwritten strings, simplify and add translations

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -3,15 +3,15 @@
         "email": "Email",
         "password": "Passwort",
         "login": "Anmeldung",
-        "clear": "Klar"
+        "clear": "Löschen"
     },
     "logout": {
-        "message": "Logging you out...",
-        "successMessage": "You've been logged out. See ya!"
+        "message": "Sie werden ausgeloggt...",
+        "successMessage": "Sie wurden ausgeloggt. Auf Wiedersehen!"
     },
     "index": {
         "title": "Wartelisten für die Stornierung von COVID-19-Impfungen in Japan",
-        "massSite": "Jeder, der 18 Jahre oder älter ist, der einen Gutschein besitzt, kann sich jetzt an den Massenimpfstellen in Tokio oder Osaka impfen lassen.",
+        "massSite": "Jeder, der über 18 Jahre ist und einen Gutschein besitzt, kann sich jetzt in den Massenimpfstellen in Tokio oder Osaka impfen lassen.",
         "register": "Zur Registrierungsseite gehen"
     },
     "add-clinic": {
@@ -19,7 +19,7 @@
         "romajiOnly": "Nur Romaji",
         "prefecture": "Präfektur",
         "city": "Stadt",
-        "ward": "Ward",
+        "ward": "Stadtviertel",
         "clinicName": "Klinikname",
         "websiteURL": "Website-URL",
         "reviewMessage": "Die von Ihnen eingereichte Klinik wird angezeigt, nachdem sie überprüft wurde!",
@@ -27,8 +27,8 @@
         "validations": {
             "cityRequired": "Stadt ist erforderlich",
             "cityValidation": "Der Stadtname muss mindestens {0} Zeichen lang sein",
-            "wardRequired": "Ward wird benötigt",
-            "wardValidation": "Der Ward Name muss mindestens {0} Zeichen lang sein",
+            "wardRequired": "Stadtviertel wird benötigt",
+            "wardValidation": "Der Stadtviertel-Name muss mindestens {0} Zeichen lang sein",
             "clinicRequired": "Klinikname ist erforderlich",
             "clinicValidation": "Der Klinikname muss aus mindestens {0} Zeichen bestehen",
             "websiteRequired": "Website-URL ist erforderlich",
@@ -38,13 +38,13 @@
     "about": {
         "welcome": "Willkommen bei „Find a Doc!“",
         "whatIsThisQ": "Was ist das?",
-        "whatIsThisA": "Dies ist eine von der Community betriebene Datenbank, um Informationen über Kliniken zu verbreiten, die Wartelisten für Impfungen anbieten, damit sie nicht verschwendet werden.",
+        "whatIsThisA": "Dies ist eine von der Community betriebene Datenbank zur Verbreitung von Informationen über Kliniken, die Wartelisten für stornierte Impfungen anbieten, sodass diese nicht verschwendet werden.",
         "trustQ": "Kann man diesen Informationen vertrauen?",
-        "trustA": "Alle Links führen zu offiziellen Ressourcen wie Klinik- und Regierungswebsites. Bitte lesen Sie diese sorgfältig durch, bevor Sie Ihre persönlichen Daten bei ihnen registrieren.",
+        "trustA": "Alle Links führen zu offiziellen Ressourcen wie Klinik- und Regierungswebsites. Bitte lesen Sie diese sorgfältig durch, bevor Sie Ihre persönlichen Daten registrieren.",
         "creatorQ": "Wer hat diese Website erstellt?",
-        "creatorA": "Diese Seite wurde von mir, LaShawn Toyoda, erstellt und gepflegt! Wenn Sie Probleme bei der Nutzung der Website haben oder auf falsche oder veraltete Informationen stoßen, kontaktieren Sie mich bitte über Twitter {0}",
+        "creatorA": "Diese Seite wurde von mir, LaShawn Toyoda, erstellt und gepflegt! Wenn Sie Probleme bei der Nutzung der Website haben oder auf falsche oder veraltete Informationen stoßen, kontaktieren Sie mich bitte über Twitter",
         "supportQ": "Wie kann ich helfen, die Datenbank zu unterstützen?",
-        "supportA": "Der beste Weg, um zu helfen, besteht darin, alle Wartelisten für Stornierungen, auf die Sie stoßen, an die Datenbank zu senden. Wenn Sie sich besonders großzügig fühlen, kaufen Sie mir bitte einen Kofi!"
+        "supportA": "Der beste Weg, um zu helfen, besteht darin, alle Wartelisten für Stornierungen von Impfungen in die Datenbank einzutragen. Wenn Sie sich besonders großzügig fühlen, spendieren Sie mir bitte einen Kofi!"
     },
     "admin": {
         "pending": {
@@ -59,7 +59,7 @@
             "clinicName": "Klinikname",
             "city": "Stadt",
             "prefecture": "Präfektur",
-            "ward": "Ward",
+            "ward": "Stadtviertel",
             "note": "Hinweis",
             "website": "Webseite",
             "flag": "Flagge"


### PR DESCRIPTION
- The translation strings for clear and ward keys have been overwritten with wrong machine tranlation -> changed back
- Added translation for the new untranslated logout keys
- Simplified/Naturalized some of the long and deeply nested machine translations