### PR TITLE
add translation for admin login page title

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -93,6 +93,7 @@
         "title": "COVID-19 Vaccination Cancellation Waiting Lists in Japan"
     },
     "login": {
+        "adminLogin": "Admin Login",
         "clear": "Clear",
         "email": "Email",
         "login": "Login",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -85,6 +85,7 @@
         "title": "COVID-19日本のワクチン接種キャンセル待ちリスト"
     },
     "login": {
+        "adminLogin": "管理者ログイン",
         "clear": "クリア",
         "email": "Eメール",
         "login": "ログイン",


### PR DESCRIPTION
Added for work on https://github.com/ourjapanlife/findadoc-frontend/issues/58

https://github.com/ourjapanlife/findadoc-frontend/pull/180