### PR TITLE
New about page string keys added

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -10,7 +10,89 @@
         "trustQ": "Can this information be trusted?",
         "welcome": "Welcome to Find a Doc, Japan!",
         "whatIsThisA": "Find a Doc is a community-driven database that was created by LaShawn Toyoda to help spread information regarding healthcare services in Japan. The project has since grown into a team of volunteers, and currently we're focusing on keeping the immigrant community informed about clinics that are offering waiting lists for vaccinations so they don't go to waste.<br /><br />In the future, we'd like to expand Find a Doc to help non-Japanese speaking residents of Japan find clinics that offer services in their native language.<br /><br /> If you find this project helpful in any way, <a href='https://ko-fi.com/theyokohamalife'><b>please donate</b></a> to help us keep the site running and to continue adding new features.",
-        "whatIsThisQ": "What is this?"
+        "whatIsThisQ": "What is this?",
+        "header": {
+            "headline": "About Find A Doc, the database reducing vaccine waste."
+        },
+        "timeline": {
+            "items": {
+                "0": {
+                    "date": "2021.06.17",
+                    "dateHeadline": "From idea to health database",
+                    "text": {
+                        "0": "On that day, LaShawn Toyoda had enough of the lack of direction from officials. A few hours later, Find a Doc is born.",
+                        "1": "This database aims to better circulate the latest information on healthcare services in Japan."
+                    },
+                    "textHeadline": "Watch our daughter, I gotta make something."
+                },
+                "1": {
+                    "date": "Presently",
+                    "dateHeadline": "A team of volunteers",
+                    "text": {
+                        "0": "Find a Doc is community-driven with the support of a team of volunteers. Currently, the team is focused on keeping the immigrant community informed about clinics offering waiting lists for vaccinations to reduce waste.",
+                        "1":  "In the future, we want Find a Doc to help non-Japanese speaking residents of Japan find clinics that offer services in their native language."
+                    },
+                    "textHeadline": "You can fill the void by citizen action.",
+                    "action": "Check out &/or join the team"
+                }
+            }
+        },
+        "kofi": {
+            "headline": "Buy us coffee",
+            "text": {
+                "0": "We are running this database after our 9-5 jobs. Help us stay awake!",
+                "1": "Consider supporting us if you find this project helped you or someone in your network."
+            },
+            "action": "Donate a cuppa"
+        },
+        "trust": {
+            "cards": {
+                "0": {
+                    "text": {
+                        "0": "All links lead to official resources such as clinic and government websites.",
+                        "1": "Read them thoroughly before registering your personal information with them."
+                    }
+                },
+                "1": {
+                    "text": {
+                        "0": "Anyone in the community can submit content to the database.",
+                        "1": "As a result, is not possible for us to guarantee that accuracy. If you notice any errors, please report the issue to moderators."
+                    }
+                },
+                "2": {
+                    "text": {
+                        "0": "Our moderators try their best to detect fraudulent information.",
+                        "1": "Even so, research any service that you find on here before visiting the location or submitting your personal information to a third-party website."
+                    }
+                }
+            },
+            "footer": {
+                "headline": "This is an open-source project, and we are not liable for any damages that may be incurred from the use of Find a Doc.",
+                "license": "Read more about it in our license."
+            },
+            "header": {
+                "headline": "Can this information be trusted?",
+                "subheadline": "In short, yes, but do your due diligence"
+            }
+        },
+        "team": {
+            "header": {
+                "headline": "Meet the Team"
+            },
+            "moreContributors": {
+                "headline": "Plus many more members who have lent us a helping hand!",
+                "action": {
+                    "text": "Find them on our {frontend} and {localization} Github contributors pages",
+                    "frontend": "front end",
+                    "localization": "localization"
+                }
+            },
+            "join": {
+                "headline": "Does Find a Doc’s mission spark your interests?",
+                "subheadline": "Join us over on GitHub to see how you can contribute!",
+                "action": "I want to join!"
+            }
+        }
     },
     "activeClinic": {
         "data": "Active Clinic Data",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,15 +1,15 @@
 {
     "about": {
         "header": {
-            "headline": "About Find A Doc, the database reducing vaccine waste."
+            "headline": "About Find A Doc, the health database for Japan's international community"
         },
         "kofi": {
             "headline": "Buy us coffee",
             "text": {
                 "0": "We are running this database after our 9-5 jobs. Help us stay awake!",
-                "1": "Consider supporting us if you find this project helped you or someone in your network."
+                "1": "Consider supporting us if this project has helped you or someone you know."
             },
-            "action": "Donate a cuppa"
+            "action": "Donate"
         },
         "team": {
             "header": {
@@ -32,11 +32,11 @@
         "timeline": {
             "items": {
                 "0": {
-                    "date": "2021.06.17",
+                    "date": "2021.06.13",
                     "dateHeadline": "From idea to health database",
                     "text": {
-                        "0": "On that day, LaShawn Toyoda had enough of the lack of direction from officials. A few hours later, Find a Doc is born.",
-                        "1": "This database aims to better circulate the latest information on healthcare services in Japan."
+                        "0": "LaShawn Toyoda had enough about the lack of clear information regarding the vaccine rollout in Japan from governing officials. A few hours later, Find a Doc was born.",
+                        "1": "This database aims to help keep the international community of Japan informed about critical healthcare services in Japan."
                     },
                     "textHeadline": "Watch our daughter, I gotta make something."
                 },
@@ -44,11 +44,11 @@
                     "date": "Presently",
                     "dateHeadline": "A team of volunteers",
                     "text": {
-                        "0": "Find a Doc is community-driven with the support of a team of volunteers. Currently, the team is focused on keeping the immigrant community informed about clinics offering waiting lists for vaccinations to reduce waste.",
+                        "0": "Find a Doc is community-driven with the support of a team of volunteers. Currently, the team is focused on keeping the international community of Japan informed about clinics offering waiting lists for vaccinations to reduce waste.",
                         "1":  "In the future, we want Find a Doc to help non-Japanese speaking residents of Japan find clinics that offer services in their native language."
                     },
                     "textHeadline": "You can fill the void by citizen action.",
-                    "action": "Check out &/or join the team"
+                    "action": "Join our team"
                 }
             }
         },
@@ -56,20 +56,20 @@
             "cards": {
                 "0": {
                     "text": {
-                        "0": "All links lead to official resources such as clinic and government websites.",
+                        "0": "We try to make sure that all links lead to official resources such as clinic and government websites.",
                         "1": "Read them thoroughly before registering your personal information with them."
                     }
                 },
                 "1": {
                     "text": {
                         "0": "Anyone in the community can submit content to the database.",
-                        "1": "As a result, is not possible for us to guarantee that accuracy. If you notice any errors, please report the issue to moderators."
+                        "1": "As a result, is not possible for us to guarantee complete accuracy. If you notice any errors, please report them to moderators."
                     }
                 },
                 "2": {
                     "text": {
                         "0": "Our moderators try their best to detect fraudulent information.",
-                        "1": "Even so, research any service that you find on here before visiting the location or submitting your personal information to a third-party website."
+                        "1": "However, we strongly encourage you to do additional research for any services that you find through Find a Doc. Use your best judgment before visiting any of the locations that are listed in the database, or before submitting your personal information to their websites."
                     }
                 }
             },
@@ -79,7 +79,7 @@
             },
             "header": {
                 "headline": "Can this information be trusted?",
-                "subheadline": "In short, yes, but do your due diligence"
+                "subheadline": "Yes, to some degree, but do your due diligence."
             }
         }
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,18 +1,33 @@
 {
     "about": {
-        "contributorLeads": "Our Team",
-        "contributorQ": "Who develops this site?",
-        "creatorA": "This site was created and maintained by me, LaShawn Toyoda! If you have any trouble using the site or come across incorrect or outdated information, please contact me through Twitter {0}",
-        "creatorQ": "Who created this website?",
-        "supportA": "If you'd like to be part of the Find a Doc community, <a href='https://github.com/ourjapanlife'>join us over on GitHub</a> to see what we could use your help with!",
-        "supportQ": "How Can I Contribute?",
-        "trustA": "All of the links lead to official resources such as clinic and government websites. Please read them thoroughly before registering your personal information with them.<br /><br /> Please understand that because this database consists of content that can be submitted by anyone, it is not possible for us to guarantee that all of the information entirely accurate or up to date. <br /><br /> Our moderators try their best to make sure fraudulent information doesn't get published, but ask that you research any service that you find on here before visiting the location or submitting your personal information to a third-party website.<br /><br /> This is an open-source project, and we are not liable for any damages that may be incurred from the use of Find a Doc.<br /><br /><a href='https://github.com/ourjapanlife/findadoc-frontend/blob/f9c8af1dbc5f70f9196442f1170a86581f776400/LICENSE'> Read more about it in our license.</a>",
-        "trustQ": "Can this information be trusted?",
-        "welcome": "Welcome to Find a Doc, Japan!",
-        "whatIsThisA": "Find a Doc is a community-driven database that was created by LaShawn Toyoda to help spread information regarding healthcare services in Japan. The project has since grown into a team of volunteers, and currently we're focusing on keeping the immigrant community informed about clinics that are offering waiting lists for vaccinations so they don't go to waste.<br /><br />In the future, we'd like to expand Find a Doc to help non-Japanese speaking residents of Japan find clinics that offer services in their native language.<br /><br /> If you find this project helpful in any way, <a href='https://ko-fi.com/theyokohamalife'><b>please donate</b></a> to help us keep the site running and to continue adding new features.",
-        "whatIsThisQ": "What is this?",
         "header": {
             "headline": "About Find A Doc, the database reducing vaccine waste."
+        },
+        "kofi": {
+            "headline": "Buy us coffee",
+            "text": {
+                "0": "We are running this database after our 9-5 jobs. Help us stay awake!",
+                "1": "Consider supporting us if you find this project helped you or someone in your network."
+            },
+            "action": "Donate a cuppa"
+        },
+        "team": {
+            "header": {
+                "headline": "Meet the Team"
+            },
+            "moreContributors": {
+                "headline": "Plus many more members who have lent us a helping hand!",
+                "action": {
+                    "text": "Find them on our {frontend} and {localization} Github contributors pages",
+                    "frontend": "front end",
+                    "localization": "localization"
+                }
+            },
+            "join": {
+                "headline": "Does Find a Doc’s mission spark your interests?",
+                "subheadline": "Join us over on GitHub to see how you can contribute!",
+                "action": "I want to join!"
+            }
         },
         "timeline": {
             "items": {
@@ -36,14 +51,6 @@
                     "action": "Check out &/or join the team"
                 }
             }
-        },
-        "kofi": {
-            "headline": "Buy us coffee",
-            "text": {
-                "0": "We are running this database after our 9-5 jobs. Help us stay awake!",
-                "1": "Consider supporting us if you find this project helped you or someone in your network."
-            },
-            "action": "Donate a cuppa"
         },
         "trust": {
             "cards": {
@@ -73,24 +80,6 @@
             "header": {
                 "headline": "Can this information be trusted?",
                 "subheadline": "In short, yes, but do your due diligence"
-            }
-        },
-        "team": {
-            "header": {
-                "headline": "Meet the Team"
-            },
-            "moreContributors": {
-                "headline": "Plus many more members who have lent us a helping hand!",
-                "action": {
-                    "text": "Find them on our {frontend} and {localization} Github contributors pages",
-                    "frontend": "front end",
-                    "localization": "localization"
-                }
-            },
-            "join": {
-                "headline": "Does Find a Doc’s mission spark your interests?",
-                "subheadline": "Join us over on GitHub to see how you can contribute!",
-                "action": "I want to join!"
             }
         }
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,7 @@
                 "0": "We are running this database after our 9-5 jobs. Help us stay awake!",
                 "1": "Consider supporting us if this project has helped you or someone you know."
             },
-            "action": "Donate"
+            "action": "Donate a cup"
         },
         "team": {
             "header": {
@@ -69,7 +69,7 @@
                 "2": {
                     "text": {
                         "0": "Our moderators try their best to detect fraudulent information.",
-                        "1": "However, we strongly encourage you to do additional research for any services that you find through Find a Doc. Use your best judgment before visiting any of the locations that are listed in the database, or before submitting your personal information to their websites."
+                        "1": "However, we strongly encourage you to use your best judgment and do additional research for any services you discover through Find a Doc."
                     }
                 }
             },
@@ -79,7 +79,7 @@
             },
             "header": {
                 "headline": "Can this information be trusted?",
-                "subheadline": "Yes, to some degree, but do your due diligence."
+                "subheadline": "In short, yes, but do your due diligence."
             }
         }
     },


### PR DESCRIPTION
Adds strings for the new page introduced in [the frontend repo](https://github.com/ourjapanlife/findadoc-frontend/pull/251), and deletes old about page string content.